### PR TITLE
Fixed the issue: #115002433

### DIFF
--- a/widget/app.js
+++ b/widget/app.js
@@ -169,12 +169,12 @@
                         $("#showFeedBtn").click();
                     }
                     else
-                        buildfire.navigation.navigateHome();
+                        buildfire.navigation._goBackOne();
                 }
                 else if (path.indexOf('/nowplaying') == 0)
                     Location.go('#/media/' + path.split('/')[2]);
                 else
-                    buildfire.navigation.navigateHome();
+                    buildfire.navigation._goBackOne();
             }
         }]);
 


### PR DESCRIPTION
If the Media Center is in a folder, clicking back does not take the user back to that folder (breadcrumbs is not working properly): Fixed