### PR TITLE
Add skeleton loading state to widget home

### DIFF
--- a/widget/index.html
+++ b/widget/index.html
@@ -22,6 +22,7 @@
     <script src="../../../scripts/buildfire.min.js"></script>
     <script src="../../../scripts/buildfire/services/fileSystem/fileManager.js"></script>
     <script src="../../../scripts/buildfire/components/drawer/drawer.js"></script>
+    <script src="../../../scripts/buildfire/components/skeleton/skeleton.js"></script>
     <script src="../../../scripts/angular/angular.min.js"></script>
     <script src="../../../scripts/angular/angular-route.min.js"></script>
     <script src="../../../scripts/angular/angular-animate.min.js"></script>


### PR DESCRIPTION
## Summary
- include the BuildFire skeleton component script in the widget bundle
- start the skeleton loader when the home view fetches data and stop it after results or cached data resolve
- restart the skeleton when refreshing content so empty states have a consistent loading treatment

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dafcb786048321af86a0cbd807260e