### PR TITLE
Revamp loadImage directive loader handling

### DIFF
--- a/widget/assets/css/widget.app.css
+++ b/widget/assets/css/widget.app.css
@@ -1576,3 +1576,48 @@ input[type="checkbox"]:checked+.subcategory-label.minus::before {
         height: 32px !important;
     }
 }
+
+.load-image-container {
+    position: relative;
+    width: 100%;
+    display: block;
+}
+
+.load-image-container .load-image-img {
+    display: block;
+    max-width: 100%;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.load-image-container .load-image-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 3px solid rgba(0, 0, 0, 0.1);
+    border-top-color: rgba(0, 0, 0, 0.45);
+    transform: translate(-50%, -50%);
+    animation: load-image-spin 0.8s linear infinite;
+    pointer-events: none;
+}
+
+.load-image-container.load-image-ready .load-image-img {
+    opacity: 1;
+}
+
+.load-image-container.load-image-ready .load-image-spinner {
+    display: none;
+}
+
+@keyframes load-image-spin {
+    from {
+        transform: translate(-50%, -50%) rotate(0deg);
+    }
+
+    to {
+        transform: translate(-50%, -50%) rotate(360deg);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder GIF used by the loadImage directive with a CSS-based loading container
- manage loader visibility during Buildfire image processing and image load events
- add styling for the new loader container and spinner animation in the widget styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbfbf70e648321af07f35455e596b5